### PR TITLE
Fix init_db for missing data directory

### DIFF
--- a/backend/scripts/init_db.js
+++ b/backend/scripts/init_db.js
@@ -1,5 +1,10 @@
+const fs = require('fs');
+const path = require('path');
 const { createUserTable } = require("../src/models/userModel");
 const { createCrmTables } = require("../src/models/crmModel");
+
+// Ensure the data directory exists so SQLite can create the database file
+fs.mkdirSync(path.resolve(__dirname, '../data'), { recursive: true });
 
 createUserTable();
 createCrmTables();


### PR DESCRIPTION
## Summary
- ensure backend data directory exists during DB init

## Testing
- `npm run build` in `frontend`
- `node scripts/init_db.js` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_687022036a5483279f81efc2ebf7d43d